### PR TITLE
Add Critical failure if no default lpad in config

### DIFF
--- a/aiida_fireworks_scheduler/cmdline.py
+++ b/aiida_fireworks_scheduler/cmdline.py
@@ -46,6 +46,15 @@ def duplicate_fe(computer: Computer, include_codes, input_plugin, suffix,
     from aiida import orm
     from aiida.orm.utils.builders.computer import ComputerBuilder
 
+    from fireworks.fw_config import LAUNCHPAD_LOC
+
+    if LAUNCHPAD_LOC is None:
+        echo.echo_critical(
+            'Cannot find the default Fireworks launchpad. '
+            'Please make sure you have configured Fireworks correctly, see '
+            'https://materialsproject.github.io/fireworks/config_tutorial.html'
+        )
+
     builder = ComputerBuilder.from_computer(computer)
     if 'slurm' in computer.scheduler_type or job_should_keep_env:
         builder.scheduler = "fireworks_scheduler.keepenv"


### PR DESCRIPTION
If the user tries to duplicate a computer to use with the `fireworks`
scheduler when no default launchpad has been configured, this currently
fails with an error message that is difficult to understand. Here we simply
add a check that there is a default launchpad configured, and echo a
critical failure that is more helpful in case there hasn't.